### PR TITLE
Research Study users need to remove patients from the list sometimes -

### DIFF
--- a/research/__init__.py
+++ b/research/__init__.py
@@ -17,6 +17,9 @@ class ResearchStudyPlugin(plugins.OpalPlugin):
             'js/research/controllers/discharge.js'
         ]
     }
+
+    actions = 'actions/remove_research_patient.html',
+
     def restricted_teams(self, user):
         return get_study_teams(user)
 

--- a/research/templates/actions/remove_research_patient.html
+++ b/research/templates/actions/remove_research_patient.html
@@ -1,0 +1,9 @@
+<p ng-show="episode.category == 'Research'">
+  <button 
+     ng-hide="profile.readonly"
+     ng-click="dischargeEpisode(episode)"
+     class="btn btn-primary btn-sm">
+    <i class="fa fa-remove"></i>
+    Remove
+  </button>
+</p>

--- a/research/templates/research/discharge.html
+++ b/research/templates/research/discharge.html
@@ -1,30 +1,15 @@
-<div class="modal-header">
-  <button type="button" class="close" ng-click="cancel()">×</button>
-  <h3>Discharge</h3>
-</div>
-<div class="modal-body">
-  <form>
-    <div>
-      <label class="radio">
-	<input type="radio" ng-model="editing.category" value="ineligible">
-	ineligible
-      </label>
-      <label class="radio">
-	<input type="radio" ng-model="editing.category" value="Deceased">
-	Deceased
-      </label>
-    </div>
-    <div>
-      <label class="control-label">Date of discharge</label>
-      <div class="controls">
-	<input type="text" ng-model="editing.discharge_date" 
-               bs-datepicker 
-               data-min-date="[[editing.date_of_admission]]">
-      </div>
-    </div>
-  </form>
-</div>
-<div class="modal-footer">
+{% extends 'modal_base.html' %}
+{% load forms %}
+
+{% block icon_name %}fa fa-remove{% endblock %}
+{% block title %}Discharge{% endblock %}
+{% block modal_body %}
+<form class="form-horizontal">
+  {% radio label="Reason" model="editing.category" lookuplist="['Ineligible', 'Deceased', 'Duplicate']" %}
+  {% datepicker label="Date of removal" model="editing.discharge_date" %}
+</form>
+{% endblock %}
+{% block modal_save %}
   <button class="btn btn-primary" ng-click="discharge()">Discharge</button>
-  <button class="btn" ng-click="cancel()">Cancel</button>
-</div>
+{% endblock %}
+{% block modal_another %}{% endblock %}


### PR DESCRIPTION
because they're mistakes, or because they're unenrolled.

This functionality was lost in a previous commit that attempted to
restrict some of the permissions around actions - here we explicitly
add it back in for Research episodes.

refs openhealthcare/opal-research#55